### PR TITLE
Adds support for publishing source artifact

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,7 +1,6 @@
 import com.jfrog.bintray.gradle.BintrayExtension
 import com.jfrog.bintray.gradle.BintrayExtension.PackageConfig
 import com.jfrog.bintray.gradle.BintrayExtension.VersionConfig
-import org.jetbrains.kotlin.gradle.plugin.KotlinSourceSet
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 import org.kt3k.gradle.plugin.CoverallsPluginExtension
 import pl.allegro.tech.build.axion.release.domain.ChecksConfig
@@ -126,6 +125,10 @@ configure<BintrayExtension> {
 
 configure<CoverallsPluginExtension> {
     sourceDirs = sourceDirs + "src/main/kotlin"
+}
+
+configure<JavaPluginExtension> {
+    withSourcesJar()
 }
 
 tasks {


### PR DESCRIPTION
Configures gradle to include a jar with the source code when building the project.
The source jar will be also including when publishing the artifacts to Bintray, ensuring it can also be synchronized to jCenter.